### PR TITLE
emit 'SHAPE_CREATED' when shape was created

### DIFF
--- a/client/src/core/drawing/drawing.js
+++ b/client/src/core/drawing/drawing.js
@@ -87,6 +87,7 @@ xrx.drawing.Position = {
 xrx.drawing.EventType = {
   VIEWBOX_CHANGE: 'eventViewboxChange',
   SHAPE_MODIFY: 'eventShapeModify',
+  SHAPE_CREATED: 'eventShapeCreated',
   SHAPE_HOVER_IN: 'eventShapeHoverIn',
   SHAPE_HOVER_MOVE: 'eventShapeHoverMove',
   SHAPE_HOVER_OUT: 'eventShapeHoverOut',

--- a/client/src/core/drawing/drawingCreatable.js
+++ b/client/src/core/drawing/drawingCreatable.js
@@ -86,6 +86,7 @@ xrx.drawing.Creatable.prototype.handleCreated = function(shape) {
     this.drawing_.getLayerShapeCreate().removeShapes();
     this.drawing_.draw();
   }
+  this.dispatchExternal(xrx.drawing.EventType.SHAPE_CREATED, this.drawing_, shape);
 };
 
 


### PR DESCRIPTION
This allows clients to react to shapes being created, e.g. changing back to hover mode, setting styles etc.